### PR TITLE
Implement custom `@nowarn` and `@unused` annotations

### DIFF
--- a/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat
+
+/** Custom annotations for Scala v2.12
+  */
+package object annotation {
+  import internal._
+
+  type nowarn    = scala.annotation.nowarn
+  type nowarn2   = nowarn
+  type nowarn212 = nowarn
+  type nowarn213 = nowarnIgnored
+  type nowarn3   = nowarnIgnored
+}

--- a/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/unused.scala
+++ b/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/unused.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+import scala.annotation.meta
+
+/** Mimics `@unused` from Scala v2.13 and v3 libraries. It reproduces the same singature of the
+  * original annotation, but inerits to `@nowarn` rather than `ConstantAnnotation`.
+  *
+  * @param message
+  *   currently not in use
+  * @see
+  *   [[https://github.com/scala/scala/blob/2.13.x/src/library/scala/annotation/unused.scala]]
+  */
+@meta.getter @meta.setter
+@nowarn(
+  "cat=other&msg=Implementation restriction: subclassing ClassfileAnnotation does not\nmake your annotation visible at runtime."
+)
+class unused(message: String) extends nowarn("cat=unused") {
+  def this() = this("")
+}

--- a/annotation/src/main/scala-2.13/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-2.13/org/typelevel/scalaccompat/annotation/package.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat
+
+/** Custom annotations for Scala v2.13
+  */
+package object annotation {
+  import internal._
+
+  type nowarn    = scala.annotation.nowarn
+  type nowarn2   = nowarn
+  type nowarn212 = nowarnIgnored
+  type nowarn213 = nowarn
+  type nowarn3   = nowarnIgnored
+
+  type unused = scala.annotation.unused
+}

--- a/annotation/src/main/scala-3/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-3/org/typelevel/scalaccompat/annotation/package.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat
+
+/** Custom annotations for Scala v3
+  */
+package object annotation {
+  import internal._
+
+  type nowarn    = scala.annotation.nowarn
+  type nowarn2   = nowarnIgnored
+  type nowarn212 = nowarnIgnored
+  type nowarn213 = nowarnIgnored
+  type nowarn3   = nowarn
+
+  type unused = scala.annotation.unused
+}

--- a/annotation/src/main/scala/org/typelevel/scalaccompat/annotation/internal/nowarnIgnored.scala
+++ b/annotation/src/main/scala/org/typelevel/scalaccompat/annotation/internal/nowarnIgnored.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+package internal
+
+private[annotation] class nowarnIgnored(@unused value: String = "")
+  extends scala.annotation.Annotation

--- a/annotation/src/test/scala-2.12/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
+++ b/annotation/src/test/scala-2.12/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+object CustomNowarnHelper {
+
+  def notDeprecated() = ()
+
+  @deprecated("deprecated for all Scala versions", "forever")
+  def deprecatedEverywhere() = ()
+
+  @deprecated("deprecated for Scala v2.12", "forever")
+  def deprecatedInScala212() = ()
+
+  def deprecatedInScala213() = ()
+
+  @deprecated("deprecated for Scala v2", "forever")
+  def deprecatedInScala2() = ()
+
+  def deprecatedInScala3() = ()
+}

--- a/annotation/src/test/scala-2.13/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
+++ b/annotation/src/test/scala-2.13/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+object CustomNowarnHelper {
+
+  def notDeprecated() = ()
+
+  @deprecated("deprecated for all Scala versions", "forever")
+  def deprecatedEverywhere() = ()
+
+  def deprecatedInScala212() = ()
+
+  @deprecated("deprecated for Scala v2.13", "forever")
+  def deprecatedInScala213() = ()
+
+  @deprecated("deprecated for Scala v2", "forever")
+  def deprecatedInScala2() = ()
+
+  def deprecatedInScala3() = ()
+}

--- a/annotation/src/test/scala-3/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
+++ b/annotation/src/test/scala-3/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+object CustomNowarnHelper {
+
+  def notDeprecated() = ()
+
+  @deprecated("deprecated for all Scala versions", "forever")
+  def deprecatedEverywhere() = ()
+
+  def deprecatedInScala212() = ()
+
+  def deprecatedInScala213() = ()
+
+  def deprecatedInScala2() = ()
+
+  @deprecated("deprecated for Scala v3", "forever")
+  def deprecatedInScala3() = ()
+}

--- a/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomNowarnSuite.scala
+++ b/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomNowarnSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+/** Not really a usual test suite. The purpose of this class is to fail compilation if any of the
+  * annotation tested is not working as expected.
+  */
+class CustomNowarnSuite {
+  import CustomNowarnHelper._
+
+  def testNowarn() = {
+    deprecatedEverywhere(): @nowarn("cat=deprecation")
+  }
+  def testNowarn212() = {
+    deprecatedInScala212(): @nowarn212("cat=deprecation")
+  }
+  def testNowarn213() = {
+    deprecatedInScala213(): @nowarn213("cat=deprecation")
+  }
+  def testNowarn2() = {
+    deprecatedInScala2(): @nowarn2("cat=deprecation")
+  }
+  def testNowarn3() = {
+    deprecatedInScala3(): @nowarn3("cat=deprecation")
+  }
+}

--- a/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomUnusedSuite.scala
+++ b/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomUnusedSuite.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+class CustomUnusedSuite {
+
+  def testUnusedParam(@unused unusedParam: String): Unit = {
+    (): Unit // enforces the "unused" warning on method params
+  }
+
+  def testUnusedVal(): Unit = {
+    @unused
+    val unusedLocalVal = "I am absolutely unused"
+  }
+
+  def testUnusedClass(): Unit = {
+    @unused
+    class UnusedLocalClass
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -35,5 +35,7 @@ lazy val annotation = crossProject(JVMPlatform)
     name := "scalac-compat-annotation",
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % munitVersion % Test
-    )
+    ),
+    // Required for tests but also good for the main code.
+    tlFatalWarnings := true
   )


### PR DESCRIPTION
1. Introduces a bunch of Scala-version specific `@nowarnX` annotation which map to a real `scala.annotation.nowarn` according to the table (copied from http4s/http4s#6751):
   | Scala | 2.12 | 2.13 | 3 |
   | -- | -- | -- | -- |
   | `@nowarn` | ✅ | ✅ | ✅ |
   | `@nowarn2` | ✅ | ✅ | ☠️ |
   | `@nowarn212` | ✅ | ☠️ | ☠️ |
   | `@nowarn213` | ☠️ | ✅ | ☠️ |
   | `@nowarn3` | ☠️ | ☠️ | ✅ |

   `@nowarn` is identical to `scala.annotation.nowarn` but added to the library's package just for convenience, because it allows to import it with
   ```scala
   import org.typelevel.scalaccompat.annotation._
   ```
   along with all the other custom annotations.

2. Adds a handy `@unused` annotation to Scala v2.12 which is not implemented natively in there.