### PR TITLE
Final fixes and improvements

### DIFF
--- a/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/unused.scala
+++ b/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/unused.scala
@@ -30,6 +30,6 @@ import scala.annotation.meta
 @nowarn(
   "cat=other&msg=Implementation restriction: subclassing ClassfileAnnotation does not\nmake your annotation visible at runtime."
 )
-class unused(@nowarn("cat=unused") message: String) extends nowarn("cat=unused") {
+class unused(@unused message: String) extends nowarn("cat=unused") {
   def this() = this("")
 }

--- a/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/unused.scala
+++ b/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/unused.scala
@@ -30,6 +30,6 @@ import scala.annotation.meta
 @nowarn(
   "cat=other&msg=Implementation restriction: subclassing ClassfileAnnotation does not\nmake your annotation visible at runtime."
 )
-class unused(message: String) extends nowarn("cat=unused") {
+class unused(@nowarn("cat=unused") message: String) extends nowarn("cat=unused") {
   def this() = this("")
 }

--- a/annotation/src/test/scala-2.12/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
+++ b/annotation/src/test/scala-2.12/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
@@ -28,8 +28,13 @@ object CustomNowarnHelper {
 
   def deprecatedInScala213() = ()
 
-  @deprecated("deprecated for Scala v2", "forever")
+  @deprecated("deprecated for Scala v2.12", "forever")
   def deprecatedInScala2() = ()
 
   def deprecatedInScala3() = ()
+
+  @deprecated("deprecated for Scala v2.12", "forever")
+  def deprecatedInScala212andScala3() = ()
+
+  def deprecatedInScala213andScala3() = ()
 }

--- a/annotation/src/test/scala-2.13/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
+++ b/annotation/src/test/scala-2.13/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
@@ -28,8 +28,13 @@ object CustomNowarnHelper {
   @deprecated("deprecated for Scala v2.13", "forever")
   def deprecatedInScala213() = ()
 
-  @deprecated("deprecated for Scala v2", "forever")
+  @deprecated("deprecated for Scala v2.13", "forever")
   def deprecatedInScala2() = ()
 
   def deprecatedInScala3() = ()
+
+  def deprecatedInScala212andScala3() = ()
+
+  @deprecated("deprecated for Scala v2.13", "forever")
+  def deprecatedInScala213andScala3() = ()
 }

--- a/annotation/src/test/scala-3/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
+++ b/annotation/src/test/scala-3/org/typelevel/scalaccompat/annotation/CustomNowarnHelper.scala
@@ -31,4 +31,10 @@ object CustomNowarnHelper {
 
   @deprecated("deprecated for Scala v3", "forever")
   def deprecatedInScala3() = ()
+
+  @deprecated("deprecated for Scala v3", "forever")
+  def deprecatedInScala212andScala3() = ()
+
+  @deprecated("deprecated for Scala v3", "forever")
+  def deprecatedInScala213andScala3() = ()
 }

--- a/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomNowarnSuite.scala
+++ b/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomNowarnSuite.scala
@@ -37,4 +37,20 @@ class CustomNowarnSuite {
   def testNowarn3() = {
     deprecatedInScala3(): @nowarn3("cat=deprecation")
   }
+  def testNowarn212and3() = {
+    deprecatedInScala212andScala3(): @nowarn212("cat=deprecation") @nowarn3("cat=deprecation")
+  }
+  def testNowarn213and3() = {
+    deprecatedInScala213andScala3(): @nowarn213("cat=deprecation") @nowarn3("cat=deprecation")
+  }
+
+  // Real-world test case: using `scala.collection.Stream`
+  // which is deprecated since Scala v2.13 (but not in v2.12).
+  @nowarn213("cat=deprecation")
+  @nowarn3("cat=deprecation")
+  def testScalaCollectionStream: Stream[Int] = {
+    Stream
+      .iterate((1, 1)) { case (a2, a1) => (a1, a2 + a1) }
+      .map(_._1)
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -37,5 +37,19 @@ lazy val annotation = crossProject(JVMPlatform)
       "org.scalameta" %%% "munit" % munitVersion % Test
     ),
     // Required for tests but also good for the main code.
-    tlFatalWarnings := true
+    tlFatalWarnings := true,
+    scalacOptions := {
+      scalacOptions.value
+        .filterNot { opt =>
+          // Remove all partially defined options like '-Xlint:-unused'.
+          opt.startsWith("-Xlint") ||
+          opt.startsWith("-Ywarn-unused") ||
+          opt.startsWith("-Wunused")
+        } ++
+        CrossVersion.partialVersion(scalaVersion.value).fold(Seq.empty[String]) {
+          case (2, 12) => Seq("-Xlint", "-Ywarn-unused")
+          case (2, 13) => Seq("-Xlint", "-Wunused")
+          case (3, _)  => Seq("-Wunused:all")
+        }
+    }
   )


### PR DESCRIPTION
Turned out that `scalacOptions` are set to be too loose for Scala v2.12 by default and thus do not emit warnings in cases when the `@nowarn` annotation is not used. Since it is the case the tests rely on, this PR tightens the settings making them as strict as possible in terms of warnings.

Then it adds more test cases for the custom `@nowarnX` annotations.