### PR TITLE
Add `@uncheckedVariance` annotations

### DIFF
--- a/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/package.scala
@@ -28,4 +28,10 @@ package object annotation {
   type nowarn3   = nowarnIgnored
 
   type targetName3 = targetNameIgnored
+
+  type uncheckedVariance    = scala.annotation.unchecked.uncheckedVariance
+  type uncheckedVariance2   = uncheckedVariance
+  type uncheckedVariance212 = uncheckedVariance
+  type uncheckedVariance213 = uncheckedVarianceIgnored
+  type uncheckedVariance3   = uncheckedVarianceIgnored
 }

--- a/annotation/src/main/scala-2.13/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-2.13/org/typelevel/scalaccompat/annotation/package.scala
@@ -29,5 +29,11 @@ package object annotation {
 
   type targetName3 = targetNameIgnored
 
+  type uncheckedVariance    = scala.annotation.unchecked.uncheckedVariance
+  type uncheckedVariance2   = uncheckedVariance
+  type uncheckedVariance212 = uncheckedVarianceIgnored
+  type uncheckedVariance213 = uncheckedVariance
+  type uncheckedVariance3   = uncheckedVarianceIgnored
+
   type unused = scala.annotation.unused
 }

--- a/annotation/src/main/scala-3/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-3/org/typelevel/scalaccompat/annotation/package.scala
@@ -29,5 +29,11 @@ package object annotation {
 
   type targetName3 = scala.annotation.targetName
 
+  type uncheckedVariance    = scala.annotation.unchecked.uncheckedVariance
+  type uncheckedVariance2   = uncheckedVarianceIgnored
+  type uncheckedVariance212 = uncheckedVarianceIgnored
+  type uncheckedVariance213 = uncheckedVarianceIgnored
+  type uncheckedVariance3   = uncheckedVariance
+
   type unused = scala.annotation.unused
 }

--- a/annotation/src/main/scala/org/typelevel/scalaccompat/annotation/internal/uncheckedVarianceIgnored.scala
+++ b/annotation/src/main/scala/org/typelevel/scalaccompat/annotation/internal/uncheckedVarianceIgnored.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+package internal
+
+private[annotation] class uncheckedVarianceIgnored extends scala.annotation.Annotation

--- a/annotation/src/test/scala-2.12/org/typelevel/scalaccompat/annotation/CustomUncheckedVarianceHelper.scala
+++ b/annotation/src/test/scala-2.12/org/typelevel/scalaccompat/annotation/CustomUncheckedVarianceHelper.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+object CustomUncheckedVarianceHelper {
+  trait Invariant[A]
+  trait Invariant2[A]
+  trait Invariant212[A]
+  trait Invariant213[+A]
+  trait Invariant3[+A]
+}

--- a/annotation/src/test/scala-2.13/org/typelevel/scalaccompat/annotation/CustomUncheckedVarianceHelper.scala
+++ b/annotation/src/test/scala-2.13/org/typelevel/scalaccompat/annotation/CustomUncheckedVarianceHelper.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+object CustomUncheckedVarianceHelper {
+  trait Invariant[A]
+  trait Invariant2[A]
+  trait Invariant212[+A]
+  trait Invariant213[A]
+  trait Invariant3[+A]
+}

--- a/annotation/src/test/scala-3/org/typelevel/scalaccompat/annotation/CustomUncheckedVarianceHelper.scala
+++ b/annotation/src/test/scala-3/org/typelevel/scalaccompat/annotation/CustomUncheckedVarianceHelper.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+object CustomUncheckedVarianceHelper {
+  trait Invariant[A]
+  trait Invariant2[+A]
+  trait Invariant212[+A]
+  trait Invariant213[+A]
+  trait Invariant3[A]
+}

--- a/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomUncheckedVarianceSuite.scala
+++ b/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomUncheckedVarianceSuite.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+import CustomUncheckedVarianceHelper._
+
+object CustomUncheckedVarianceSuite {
+
+  class Covariant[+A]    extends Invariant[A @uncheckedVariance]
+  class Covariant2[+A]   extends Invariant2[A @uncheckedVariance2]
+  class Covariant212[+A] extends Invariant212[A @uncheckedVariance212]
+  class Covariant213[+A] extends Invariant213[A @uncheckedVariance213]
+  class Covariant3[+A]   extends Invariant3[A @uncheckedVariance3]
+
+}


### PR DESCRIPTION
I think the only real motivation to use this is to workaround compiler bugs. For example in https://github.com/typelevel/cats/commit/828ac3ff83fb304f89c6879f3b8a08242f34f978 we could use `@uncheckedVariance213` to continue being checked in Scala 2.12 and Scala 3.

~~Adding some tests for this is proving to be tricky ... any ideas?~~ figured something out :)