### PR TITLE
Add `@threadUnsafe3`

### DIFF
--- a/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/package.scala
@@ -29,6 +29,8 @@ package object annotation {
 
   type targetName3 = targetNameIgnored
 
+  type threadUnsafe3 = threadUnsafeIgnored
+
   type uncheckedVariance    = scala.annotation.unchecked.uncheckedVariance
   type uncheckedVariance2   = uncheckedVariance
   type uncheckedVariance212 = uncheckedVariance

--- a/annotation/src/main/scala-2.13/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-2.13/org/typelevel/scalaccompat/annotation/package.scala
@@ -29,6 +29,8 @@ package object annotation {
 
   type targetName3 = targetNameIgnored
 
+  type threadUnsafe3 = threadUnsafeIgnored
+
   type uncheckedVariance    = scala.annotation.unchecked.uncheckedVariance
   type uncheckedVariance2   = uncheckedVariance
   type uncheckedVariance212 = uncheckedVarianceIgnored

--- a/annotation/src/main/scala-3/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-3/org/typelevel/scalaccompat/annotation/package.scala
@@ -29,6 +29,8 @@ package object annotation {
 
   type targetName3 = scala.annotation.targetName
 
+  type threadUnsafe3 = scala.annotation.threadUnsafe
+
   type uncheckedVariance    = scala.annotation.unchecked.uncheckedVariance
   type uncheckedVariance2   = uncheckedVarianceIgnored
   type uncheckedVariance212 = uncheckedVarianceIgnored

--- a/annotation/src/main/scala/org/typelevel/scalaccompat/annotation/internal/threadUnsafeIgnored.scala
+++ b/annotation/src/main/scala/org/typelevel/scalaccompat/annotation/internal/threadUnsafeIgnored.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+package internal
+
+private[annotation] class threadUnsafeIgnored extends scala.annotation.Annotation

--- a/annotation/src/test/scala-2/org/typelevel/scalaccompat/annotation/CustomThreadUnsafeHelper.scala
+++ b/annotation/src/test/scala-2/org/typelevel/scalaccompat/annotation/CustomThreadUnsafeHelper.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+object CustomThreadUnsafeHelper {
+  final val isScala3 = false
+}

--- a/annotation/src/test/scala-3/org/typelevel/scalaccompat/annotation/CustomThreadUnsafeHelper.scala
+++ b/annotation/src/test/scala-3/org/typelevel/scalaccompat/annotation/CustomThreadUnsafeHelper.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+object CustomThreadUnsafeHelper {
+  final val isScala3 = true
+}

--- a/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomThreadUnsafeSuite.scala
+++ b/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomThreadUnsafeSuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+import munit.FunSuite
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.Future
+
+class CustomThreadUnsafeSuite extends FunSuite {
+
+  val counter = new AtomicInteger
+
+  @threadUnsafe3
+  lazy val foo = {
+    counter.incrementAndGet()
+    Thread.sleep(100)
+    ()
+  }
+
+  test("threadUnsafe3 respected on Scala 3 only") {
+    Future.sequence(List(Future(foo), Future(foo))).map { _ =>
+      if (CustomThreadUnsafeHelper.isScala3) {
+        assertEquals(counter.get(), 2)
+      } else { // Scala 2
+        assertEquals(counter.get(), 1)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This annotation is a nice optimization for the common case where a `lazy val` initializes a pure value and does not need to be synchronized.

Code that is performance sensitive on Scala 2 will still need to avoid `lazy val`, but for casual code that is already using it at least we can squeeze out some extra performance on Scala 3.