### PR TITLE
Add `@static3`

### DIFF
--- a/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/package.scala
@@ -27,6 +27,8 @@ package object annotation {
   type nowarn213 = nowarnIgnored
   type nowarn3   = nowarnIgnored
 
+  type static3 = staticIgnored
+
   type targetName3 = targetNameIgnored
 
   type threadUnsafe3 = threadUnsafeIgnored

--- a/annotation/src/main/scala-2.13/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-2.13/org/typelevel/scalaccompat/annotation/package.scala
@@ -27,6 +27,8 @@ package object annotation {
   type nowarn213 = nowarn
   type nowarn3   = nowarnIgnored
 
+  type static3 = staticIgnored
+
   type targetName3 = targetNameIgnored
 
   type threadUnsafe3 = threadUnsafeIgnored

--- a/annotation/src/main/scala-3/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-3/org/typelevel/scalaccompat/annotation/package.scala
@@ -27,6 +27,8 @@ package object annotation {
   type nowarn213 = nowarnIgnored
   type nowarn3   = nowarn
 
+  type static3 = scala.annotation.static
+
   type targetName3 = scala.annotation.targetName
 
   type threadUnsafe3 = scala.annotation.threadUnsafe

--- a/annotation/src/main/scala/org/typelevel/scalaccompat/annotation/internal/staticIgnored.scala
+++ b/annotation/src/main/scala/org/typelevel/scalaccompat/annotation/internal/staticIgnored.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+package internal
+
+private[annotation] class staticIgnored extends scala.annotation.Annotation

--- a/annotation/src/test/scala-2/org/typelevel/scalaccompat/annotation/CustomStaticHelper.scala
+++ b/annotation/src/test/scala-2/org/typelevel/scalaccompat/annotation/CustomStaticHelper.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+object CustomStaticHelper {
+  final val isScala3 = false
+}

--- a/annotation/src/test/scala-3/org/typelevel/scalaccompat/annotation/CustomStaticHelper.scala
+++ b/annotation/src/test/scala-3/org/typelevel/scalaccompat/annotation/CustomStaticHelper.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+object CustomStaticHelper {
+  final val isScala3 = true
+}

--- a/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomStaticSuite.scala
+++ b/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomStaticSuite.scala
@@ -20,7 +20,7 @@ import munit.FunSuite
 
 class CustomStaticDemo
 object CustomStaticDemo {
-  @static3 val foo = 42
+  @static3 val foo = new Object
 }
 
 class CustomStaticSuite extends FunSuite {

--- a/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomStaticSuite.scala
+++ b/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomStaticSuite.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.scalaccompat.annotation
+
+import munit.FunSuite
+
+class CustomStaticDemo
+object CustomStaticDemo {
+  @static3 val foo = 42
+}
+
+class CustomStaticSuite extends FunSuite {
+
+  test("static3 respected on Scala 3 only") {
+    val fields = classOf[CustomStaticDemo].getFields().map(_.getName).toList
+
+    if (CustomStaticHelper.isScala3) {
+      assertEquals(fields, List("foo"))
+    } else { // Scala 2
+      assertEquals(fields, Nil)
+    }
+  }
+
+}


### PR DESCRIPTION
Similar to https://github.com/typelevel/scalac-compat/pull/72, this lets us use another fancy Scala 3 optimization while still cross-compiling for Scala 2.