### PR TITLE
Fix ScalaFmt config

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,17 @@
 version = 3.7.17
 
-runner.dialect = scala213
+runner.dialect = scala213source3
+fileOverride {
+  "glob:**/*.sbt" {
+    runner.dialect = sbt1
+  }
+  "glob:**/src/{main,test}/scala-2.12/**" {
+    runner.dialect = scala212source3
+  }
+  "glob:**/src/{main,test}/scala-3/**" {
+    runner.dialect = scala3
+  }
+}
 
 preset = defaultWithAlign
 


### PR DESCRIPTION
Metals began pestering me that Scalac version in the project and `.scalafmt.conf` do not match (which is true).
Although it is not that crucial for this project, I believe it makes sense to fix it anyway.