### PR TITLE
Enforce some Scala3 new syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -22,3 +22,5 @@ indent {
   defnSite = 2
   extendSite = 2
 }
+
+rewrite.scala3.convertToNewSyntax = true

--- a/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-2.12/org/typelevel/scalaccompat/annotation/package.scala
@@ -19,7 +19,7 @@ package org.typelevel.scalaccompat
 /** Custom annotations for Scala v2.12
   */
 package object annotation {
-  import internal._
+  import internal.*
 
   type nowarn    = scala.annotation.nowarn
   type nowarn2   = nowarn

--- a/annotation/src/main/scala-2.13/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-2.13/org/typelevel/scalaccompat/annotation/package.scala
@@ -19,7 +19,7 @@ package org.typelevel.scalaccompat
 /** Custom annotations for Scala v2.13
   */
 package object annotation {
-  import internal._
+  import internal.*
 
   type nowarn    = scala.annotation.nowarn
   type nowarn2   = nowarn

--- a/annotation/src/main/scala-3/org/typelevel/scalaccompat/annotation/package.scala
+++ b/annotation/src/main/scala-3/org/typelevel/scalaccompat/annotation/package.scala
@@ -19,7 +19,7 @@ package org.typelevel.scalaccompat
 /** Custom annotations for Scala v3
   */
 package object annotation {
-  import internal._
+  import internal.*
 
   type nowarn    = scala.annotation.nowarn
   type nowarn2   = nowarnIgnored

--- a/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomNowarnSuite.scala
+++ b/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomNowarnSuite.scala
@@ -20,7 +20,7 @@ package org.typelevel.scalaccompat.annotation
   * annotation tested is not working as expected.
   */
 class CustomNowarnSuite {
-  import CustomNowarnHelper._
+  import CustomNowarnHelper.*
 
   def testNowarn() = {
     deprecatedEverywhere(): @nowarn("cat=deprecation")

--- a/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomThreadUnsafeSuite.scala
+++ b/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomThreadUnsafeSuite.scala
@@ -19,7 +19,7 @@ package org.typelevel.scalaccompat.annotation
 import munit.FunSuite
 
 import java.util.concurrent.atomic.AtomicInteger
-import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.ExecutionContext.Implicits.*
 import scala.concurrent.Future
 
 class CustomThreadUnsafeSuite extends FunSuite {

--- a/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomUncheckedVarianceSuite.scala
+++ b/annotation/src/test/scala/org/typelevel/scalaccompat/annotation/CustomUncheckedVarianceSuite.scala
@@ -16,7 +16,7 @@
 
 package org.typelevel.scalaccompat.annotation
 
-import CustomUncheckedVarianceHelper._
+import CustomUncheckedVarianceHelper.*
 
 object CustomUncheckedVarianceSuite {
 


### PR DESCRIPTION
Adds `rewrite.scala3.convertToNewSyntax = true` to **.scalafmt.conf**
thereby enforcing some Scala3 new syntax available for Scala2.